### PR TITLE
Add Prompt Mirror clarity coach application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
-# prompt-mirror
+# Prompt Mirror (Clarity Coach)
+
+Prompt Mirror is a lightweight Flask application that reviews a prompt, surfaces clarity gaps, and offers a tightened rewrite. It ships with rule-based heuristics and can optionally call OpenAI models when an `OPENAI_API_KEY` is available.
+
+## Features
+
+- ✅ Rule-based checks for roles, tasks, inputs, constraints, format, steps, examples, and success criteria
+- ⚠️ Flagging of ambiguous terms, vague quantifiers, and dangling pronouns with scoring out of 100
+- 🧩 Structured rewrite template (Role, Task, Inputs, Constraints, Output Format, Steps, Success Criteria, Refusal Boundaries)
+- 💾 Copy-to-clipboard, downloadable `.txt`, and inline diff view
+- 🎯 Preset prompts for instant experimentation
+- 🤖 Optional LLM assist (validated via Pydantic) when `OPENAI_API_KEY` is set
+
+## Getting started
+
+1. Install dependencies (Flask and Pydantic are required):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+   or install manually:
+
+   ```bash
+   pip install Flask pydantic
+   ```
+
+2. Run the development server:
+
+   ```bash
+   export FLASK_APP=t004_prompt_mirror.app
+   flask run --reload
+   ```
+
+3. Open `http://127.0.0.1:5000` in your browser, paste a prompt, and review the analysis + rewrite.
+
+### Optional OpenAI integration
+
+If `OPENAI_API_KEY` is present (and the `openai` Python package is installed), Prompt Mirror will request an LLM analysis and rewrite. Responses are validated against the rule-based schema; if anything looks off, the app falls back to the deterministic heuristics.
+
+Set a specific model with `PROMPT_MIRROR_MODEL` (defaults to `gpt-4o-mini`).
+
+## Repository layout
+
+```
+t004_prompt_mirror/
+  app.py           # Flask routes and preset definitions
+  logic.py         # Rule-based analysis and rewrite helpers
+  llm.py           # Optional OpenAI integration
+  schema.py        # Pydantic schema + validators
+  export.py        # Download helper
+  static/ui.js     # Preset loader, copy button, diff renderer
+  templates/index.html
+```
+
+## Tests
+
+This project relies on ad-hoc checks. A quick smoke test can be run with:
+
+```bash
+python -m compileall t004_prompt_mirror
+```
+
+## License
+
+MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.3
+pydantic>=1.10

--- a/t004_prompt_mirror/app.py
+++ b/t004_prompt_mirror/app.py
@@ -1,0 +1,171 @@
+"""Flask application for Prompt Mirror."""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any, Dict, List, Optional
+
+from flask import Flask, render_template, request, send_file
+
+try:  # Local package import when running via `python -m`
+    from .logic import analyze_prompt, rewrite_prompt
+    from .export import to_txt
+    from .schema import validate_or_fallback
+    try:
+        from .llm import llm_analyze, llm_rewrite
+    except Exception:  # pragma: no cover - optional dependency
+        llm_analyze = None
+        llm_rewrite = None
+except ImportError:  # pragma: no cover - support running as script
+    from logic import analyze_prompt, rewrite_prompt  # type: ignore
+    from export import to_txt  # type: ignore
+    from schema import validate_or_fallback  # type: ignore
+    try:
+        from llm import llm_analyze, llm_rewrite  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        llm_analyze = None
+        llm_rewrite = None
+
+
+app = Flask(__name__)
+MAX_INPUT_CHARS = 2000
+
+PRESETS: List[Dict[str, str]] = [
+    {
+        "id": "startup_marketing",
+        "label": "Startup marketing request",
+        "rough": "help me with a marketing plan for a small startup",
+        "polished": (
+            "Role: You are a marketing strategist for early-stage founders.\n"
+            "Task: Build a phased go-to-market roadmap with metrics.\n"
+            "Constraints: 3 channels max, $10k test budget, launch in 30 days."
+        ),
+    },
+    {
+        "id": "feature_spec",
+        "label": "Feature request with missing detail",
+        "rough": "can you build something that improves onboarding for our app?",
+        "polished": (
+            "Role: Product discovery lead.\n"
+            "Task: Draft an onboarding improvement brief with measurable outcomes.\n"
+            "Constraints: 2 experiment tracks, completion rate +20% target."
+        ),
+    },
+    {
+        "id": "analysis_request",
+        "label": "Data analysis ask",
+        "rough": "please look at the q3 numbers and tell me what stands out",
+        "polished": (
+            "Role: Data insights consultant.\n"
+            "Task: Produce a dashboard summary with anomalies and recommendations.\n"
+            "Constraints: Focus on top 3 shifts, include % deltas and owners."
+        ),
+    },
+]
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template(
+        "index.html",
+        result=None,
+        rewrite=None,
+        original_text="",
+        raw_input="",
+        trimmed_message=None,
+        analysis_error=None,
+        rewrite_error=None,
+        presets=PRESETS,
+        used_llm=False,
+        max_chars=MAX_INPUT_CHARS,
+    )
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze():
+    raw_text = request.form.get("prompt_text", "")
+    trimmed_message: Optional[str] = None
+    text = raw_text
+    if len(raw_text) > MAX_INPUT_CHARS:
+        text = raw_text[:MAX_INPUT_CHARS]
+        trimmed_message = f"Input trimmed to {MAX_INPUT_CHARS} characters."
+
+    analysis_result: Optional[Dict[str, Any]] = None
+    rewrite_result: Optional[str] = None
+    analysis_error: Optional[str] = None
+    rewrite_error: Optional[str] = None
+    used_llm = False
+
+    fallback_analysis: Optional[Dict[str, Any]] = None
+    try:
+        fallback_analysis = analyze_prompt(text)
+        analysis_result = fallback_analysis
+    except Exception as exc:  # pragma: no cover - defensive
+        analysis_error = f"Analysis failed: {exc}"
+        fallback_analysis = None
+
+    if fallback_analysis is not None and llm_analyze:
+        try:
+            llm_candidate = llm_analyze(text)
+        except Exception as exc:  # pragma: no cover - network failure
+            analysis_error = f"LLM analysis error: {exc}"
+        else:
+            if analysis_result is not None:
+                analysis_result = validate_or_fallback(llm_candidate, analysis_result)
+                used_llm = llm_candidate is not None and analysis_result is not fallback_analysis
+
+    if analysis_result is None and fallback_analysis is not None:
+        analysis_result = fallback_analysis
+
+    if analysis_result is None:
+        analysis_error = analysis_error or "Unable to analyze the prompt."
+
+    try:
+        if analysis_result is not None:
+            if used_llm and llm_rewrite:
+                llm_text = None
+                try:
+                    llm_text = llm_rewrite(analysis_result, text)
+                except Exception as exc:  # pragma: no cover - network
+                    rewrite_error = f"LLM rewrite error: {exc}"
+                if llm_text:
+                    rewrite_result = llm_text
+            if rewrite_result is None:
+                rewrite_result = rewrite_prompt(analysis_result, text)
+    except Exception as exc:
+        rewrite_error = f"Rewrite failed: {exc}"
+
+    diff_payload = {
+        "original": text,
+        "rewrite": rewrite_result or "",
+    }
+
+    return render_template(
+        "index.html",
+        result=analysis_result,
+        rewrite=rewrite_result,
+        original_text=text,
+        raw_input=raw_text,
+        trimmed_message=trimmed_message,
+        analysis_error=analysis_error,
+        rewrite_error=rewrite_error,
+        presets=PRESETS,
+        used_llm=used_llm,
+        max_chars=MAX_INPUT_CHARS,
+        diff_payload=diff_payload,
+    )
+
+
+@app.route("/download", methods=["POST"])
+def download():
+    rewrite_text = request.form.get("rewrite_text", "")
+    bytes_io = BytesIO(to_txt(rewrite_text))
+    return send_file(
+        bytes_io,
+        mimetype="text/plain",
+        as_attachment=True,
+        download_name="prompt_mirror_rewrite.txt",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(debug=True)

--- a/t004_prompt_mirror/export.py
+++ b/t004_prompt_mirror/export.py
@@ -1,0 +1,8 @@
+"""Utility helpers for exporting rewritten prompts."""
+from __future__ import annotations
+
+
+def to_txt(rewrite: str) -> bytes:
+    """Return the rewritten prompt as UTF-8 encoded bytes for download."""
+    content = rewrite or ""
+    return content.encode("utf-8")

--- a/t004_prompt_mirror/llm.py
+++ b/t004_prompt_mirror/llm.py
@@ -1,0 +1,107 @@
+"""Optional OpenAI-powered analysis helpers."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+MAX_INPUT_CHARS = 1200
+
+
+def _get_openai_client():  # pragma: no cover - depends on optional SDK
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+    try:
+        import openai
+    except ImportError:
+        return None
+
+    openai.api_key = api_key
+    return openai
+
+
+def _safe_trim(text: str) -> str:
+    if text and len(text) > MAX_INPUT_CHARS:
+        return text[:MAX_INPUT_CHARS]
+    return text or ""
+
+
+def llm_analyze(text: str) -> Optional[Dict[str, Any]]:
+    """Request an LLM-powered analysis. Returns None on error."""
+    client = _get_openai_client()
+    if client is None:
+        return None
+
+    payload = _build_analysis_prompt(_safe_trim(text))
+    try:  # pragma: no cover - network
+        response = client.ChatCompletion.create(
+            model=os.getenv("PROMPT_MIRROR_MODEL", "gpt-4o-mini"),
+            messages=payload,
+            temperature=0.1,
+            max_tokens=600,
+        )
+    except Exception:
+        return None
+
+    try:
+        content = response["choices"][0]["message"]["content"].strip()
+        return json.loads(content)
+    except Exception:
+        return None
+
+
+def llm_rewrite(analysis: Dict[str, Any], text: str) -> Optional[str]:
+    """Return an LLM-generated rewrite using the analysis."""
+    client = _get_openai_client()
+    if client is None:
+        return None
+
+    analysis_json = json.dumps(analysis, ensure_ascii=False)
+    payload = _build_rewrite_prompt(analysis_json, _safe_trim(text))
+    try:  # pragma: no cover - network
+        response = client.ChatCompletion.create(
+            model=os.getenv("PROMPT_MIRROR_MODEL", "gpt-4o-mini"),
+            messages=payload,
+            temperature=0.1,
+            max_tokens=700,
+        )
+    except Exception:
+        return None
+
+    try:
+        return response["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return None
+
+
+def _build_analysis_prompt(text: str):
+    system = (
+        "You are Prompt Mirror, a clarity coach. Respond with JSON that matches the schema."
+    )
+    user = (
+        "Analyze the following prompt. Reply with JSON only using keys checks, flags, score, and notes. "
+        "checks contains booleans for has_role, has_task, has_inputs, has_constraints, has_format, has_examples, has_steps, and has_success_criteria. "
+        "flags.ambiguous_terms and flags.vague_quantifiers are string arrays. flags.dangling_pronouns is an integer. "
+        "score is an integer 0-100. notes is an array of helpful strings."
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": f"PROMPT:\n{text}\n" + user},
+    ]
+
+
+def _build_rewrite_prompt(analysis_json: str, text: str):
+    system = (
+        "You are Prompt Mirror, a clarity coach. Rewrite prompts into structured briefs with role, task, inputs, constraints, format, steps, success criteria, and refusal boundaries sections."
+    )
+    instructions = (
+        "Use the provided analysis JSON to fill gaps. Avoid ambiguous language. Include numbered steps and measurable constraints."
+    )
+    user = (
+        f"PROMPT:\n{text}\n\nANALYSIS_JSON:\n{analysis_json}\n\n{instructions}"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]

--- a/t004_prompt_mirror/logic.py
+++ b/t004_prompt_mirror/logic.py
@@ -1,0 +1,428 @@
+"""Core rule-based analysis and rewriting utilities for Prompt Mirror."""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Dict, Iterable, List
+
+# Regular expressions for structural checks.
+ROLE_PATTERN = re.compile(r"\b(?:you are|act as)\b", re.IGNORECASE)
+TASK_PATTERN = re.compile(
+    r"^\s*(write|draft|plan|create|design|develop|compare|summarize|analyze|build|outline|generate|evaluate|produce|compose|audit|assess)\b",
+    re.IGNORECASE,
+)
+INPUT_PATTERN = re.compile(
+    r"\b(given|using|with (?:this|the)|based on|provided|attached|from)\b",
+    re.IGNORECASE,
+)
+CONSTRAINT_PATTERN = re.compile(
+    r"(constraints?|assume|exclude|limit|deadline|budget|must|exactly|at least|no more than)",
+    re.IGNORECASE,
+)
+FORMAT_PATTERN = re.compile(
+    r"\b(output|return|respond|deliver|format|present|provide)\b.*\b(json|table|markdown|bullets?|list|outline|chart)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+EXAMPLE_PATTERN = re.compile(r"\b(example|for instance|eg:|e\.g\.)", re.IGNORECASE)
+STEPS_PATTERN = re.compile(r"\b(step\s*\d+|steps|process|first|second|third|then|next|finally)\b", re.IGNORECASE)
+SUCCESS_PATTERN = re.compile(
+    r"\b(success(?: criteria| when)?|acceptance|definition of done|done when|complete when)\b",
+    re.IGNORECASE,
+)
+
+
+AMBIGUOUS_TERMS: List[str] = [
+    "help me with",
+    "help",
+    "assist",
+    "optimize",
+    "improve",
+    "better",
+    "robust",
+    "flexible",
+    "scalable",
+    "easy",
+    "efficient",
+    "modern",
+    "as needed",
+    "user friendly",
+    "marketing plan",
+    "strategy",
+    "nice",
+]
+VAGUE_QUANTIFIERS: List[str] = [
+    "some",
+    "many",
+    "several",
+    "few",
+    "often",
+    "quickly",
+    "regularly",
+    "usually",
+    "sometimes",
+    "various",
+    "numerous",
+    "couple",
+    "handful",
+    "soon",
+    "asap",
+]
+
+AMBIGUOUS_REPLACEMENTS = {
+    "help me with": "create",
+    "help": "deliver",
+    "assist": "provide",
+    "optimize": "fine-tune",
+    "improve": "strengthen",
+    "better": "enhance",
+    "marketing plan": "go-to-market roadmap",
+    "strategy": "action blueprint",
+    "user friendly": "accessible for end users",
+    "modern": "contemporary",
+}
+
+STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "of",
+    "for",
+    "with",
+    "within",
+    "on",
+    "in",
+    "to",
+    "into",
+    "me",
+    "my",
+    "our",
+    "your",
+    "their",
+    "this",
+    "that",
+    "these",
+    "those",
+    "about",
+    "at",
+    "by",
+    "from",
+    "as",
+    "it",
+    "is",
+    "are",
+    "be",
+    "need",
+    "needs",
+    "needed",
+    "please",
+    "would",
+    "could",
+    "should",
+    "can",
+    "we",
+    "i",
+}
+
+AMBIGUOUS_SET = {term.lower() for term in AMBIGUOUS_TERMS}
+VAGUE_SET = {term.lower() for term in VAGUE_QUANTIFIERS}
+
+
+def analyze_prompt(text: str) -> Dict[str, object]:
+    """Analyze a prompt and return structural checks, flags, score, and notes."""
+    source = text or ""
+    checks = {
+        "has_role": bool(ROLE_PATTERN.search(source)),
+        "has_task": bool(TASK_PATTERN.search(source)),
+        "has_inputs": bool(INPUT_PATTERN.search(source)),
+        "has_constraints": bool(_has_constraints(source)),
+        "has_format": bool(FORMAT_PATTERN.search(source)),
+        "has_examples": bool(EXAMPLE_PATTERN.search(source)),
+        "has_steps": bool(STEPS_PATTERN.search(source)),
+        "has_success_criteria": bool(SUCCESS_PATTERN.search(source)),
+    }
+
+    ambiguous_terms = _normalize_terms(_find_terms(source, AMBIGUOUS_TERMS))
+    vague_quantifiers = _find_terms(source, VAGUE_QUANTIFIERS)
+    dangling_pronouns = _count_dangling_pronouns(source)
+
+    score = _calculate_score(checks, ambiguous_terms, vague_quantifiers, dangling_pronouns)
+    notes = _build_notes(checks, ambiguous_terms, vague_quantifiers, dangling_pronouns)
+
+    return {
+        "checks": checks,
+        "flags": {
+            "ambiguous_terms": ambiguous_terms,
+            "vague_quantifiers": vague_quantifiers,
+            "dangling_pronouns": dangling_pronouns,
+        },
+        "score": score,
+        "notes": notes,
+    }
+
+
+def rewrite_prompt(analysis: Dict[str, object], text: str) -> str:
+    """Rewrite the prompt using a structured template."""
+    if analysis is None:
+        raise ValueError("analysis data is required for rewrite")
+
+    source = text or ""
+    keywords = _extract_keywords(source, limit=6)
+    focus_phrase = _build_focus_phrase(keywords)
+    audience_phrase = _build_audience_phrase(keywords)
+
+    role_line = _build_role_line(keywords)
+    task_line = _build_task_line(focus_phrase)
+    inputs_section = _build_inputs_section(focus_phrase, audience_phrase, source)
+    constraints_section = _build_constraints_section()
+    format_section = _build_format_section()
+    steps_section = _build_steps_section(focus_phrase)
+    success_section = _build_success_section()
+    refusal_section = _build_refusal_section()
+
+    sections = [
+        f"Role:\n{role_line}",
+        f"Task:\n{task_line}",
+        inputs_section,
+        constraints_section,
+        format_section,
+        steps_section,
+        success_section,
+        refusal_section,
+    ]
+
+    rewritten = "\n\n".join(sections).strip()
+    rewritten = _replace_ambiguous_terms(rewritten)
+    return rewritten
+
+
+def _has_constraints(text: str) -> bool:
+    if re.search(r"\b\d+(?:\.\d+)?\b", text):
+        return True
+    return bool(CONSTRAINT_PATTERN.search(text))
+
+
+def _find_terms(text: str, term_list: Iterable[str]) -> List[str]:
+    lowered = text.lower()
+    found: List[str] = []
+    for term in sorted(set(term_list), key=len, reverse=True):
+        pattern = re.escape(term)
+        if re.search(pattern, lowered):
+            if any(term in existing for existing in found):
+                continue
+            found.append(term)
+    return sorted(found)
+
+
+def _normalize_terms(terms: List[str]) -> List[str]:
+    normalized: List[str] = []
+    for term in terms:
+        if term == "help me with":
+            term = "help"
+        if term not in normalized:
+            normalized.append(term)
+    return normalized
+
+
+def _count_dangling_pronouns(text: str) -> int:
+    return len(
+        re.findall(
+            r"\b(?:it|this|that|they)\s+(?:is|are|was|were|should|must|can|will|need|needs)\b",
+            text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _calculate_score(
+    checks: Dict[str, bool],
+    ambiguous_terms: Iterable[str],
+    vague_quantifiers: Iterable[str],
+    dangling_pronouns: int,
+) -> int:
+    base = sum(1 for value in checks.values() if value) * 10
+    penalty = 5 * len(list(ambiguous_terms)) + 2 * len(list(vague_quantifiers)) + 3 * dangling_pronouns
+    score = base - penalty
+    return int(max(0, min(100, score)))
+
+
+def _build_notes(
+    checks: Dict[str, bool],
+    ambiguous_terms: List[str],
+    vague_quantifiers: List[str],
+    dangling_pronouns: int,
+) -> List[str]:
+    notes: List[str] = []
+    missing_messages = {
+        "has_role": "Add a clear role statement such as 'You are a specific type of expert.'",
+        "has_task": "Start with an imperative task that describes the expected action.",
+        "has_inputs": "Reference the inputs or source material the assistant should rely on.",
+        "has_constraints": "List numeric or explicit constraints to narrow the solution space.",
+        "has_format": "Specify the output format (tables, bullets, JSON, etc.).",
+        "has_examples": "Provide concrete examples to anchor expectations.",
+        "has_steps": "Describe the process or steps the assistant should follow.",
+        "has_success_criteria": "Define what success looks like or how the result will be evaluated.",
+    }
+
+    for key, message in missing_messages.items():
+        if not checks.get(key, False):
+            notes.append(message)
+
+    if ambiguous_terms:
+        notes.append(
+            "Clarify or replace ambiguous terms: "
+            + ", ".join(sorted(ambiguous_terms))
+            + "."
+        )
+    if vague_quantifiers:
+        notes.append(
+            "Quantify vague language (specify counts, ranges, or timeframes) for: "
+            + ", ".join(sorted(vague_quantifiers))
+            + "."
+        )
+    if dangling_pronouns:
+        notes.append(
+            "Resolve dangling pronouns (it/this/that/they) by naming the referent."
+        )
+    if not notes:
+        notes.append("Prompt already covers the fundamentals; refine tone or examples as needed.")
+    return notes
+
+
+def _extract_keywords(text: str, limit: int = 6) -> List[str]:
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z\-]+", text.lower())
+    filtered = [
+        token
+        for token in tokens
+        if token not in STOPWORDS
+        and token not in AMBIGUOUS_SET
+        and token not in VAGUE_SET
+        and len(token) > 2
+    ]
+    counts = Counter(filtered)
+    ordered = [word for word, _ in counts.most_common(limit)]
+    return ordered
+
+
+def _build_focus_phrase(keywords: List[str]) -> str:
+    if not keywords:
+        return "project"
+    if "startup" in keywords and "marketing" in keywords:
+        return "startup marketing initiative"
+    if len(keywords) == 1:
+        return keywords[0]
+    return f"{keywords[0]} {keywords[1]}"
+
+
+def _build_audience_phrase(keywords: List[str]) -> str:
+    if "startup" in keywords:
+        return "early-stage startup team"
+    if "students" in keywords:
+        return "student audience"
+    if "executive" in keywords or "leadership" in keywords:
+        return "executive stakeholders"
+    if keywords:
+        return f"stakeholders focused on {keywords[0]}"
+    return "target audience"
+
+
+def _build_role_line(keywords: List[str]) -> str:
+    if "marketing" in keywords:
+        return "You are a marketing strategist specializing in go-to-market execution for startups."
+    if "product" in keywords or "design" in keywords:
+        return "You are a product discovery lead who converts fuzzy requests into actionable briefs."
+    if "sales" in keywords:
+        return "You are a revenue operations advisor aligned with data-backed sales planning."
+    if "content" in keywords or "writing" in keywords:
+        return "You are an editorial architect who crafts structured content playbooks."
+    if "analysis" in keywords or "analytics" in keywords:
+        return "You are a data insights consultant focusing on evidence-based recommendations."
+    if "engineering" in keywords or "software" in keywords:
+        return "You are a delivery-focused engineering lead who defines crisp build briefs."
+    return "You are a clarity coach who turns goals into precise, testable instructions."
+
+
+def _build_task_line(focus_phrase: str) -> str:
+    return (
+        "Construct a detailed go-to-market roadmap for the "
+        f"{focus_phrase}, highlighting decisions, rationales, and metrics."
+    )
+
+
+def _build_inputs_section(focus_phrase: str, audience_phrase: str, source: str) -> str:
+    summary = _summarize_source(source)
+    items = [
+        f"- Primary focus: {focus_phrase}.",
+        f"- Audience/context: {audience_phrase}.",
+        f"- Source request recap: {summary}",
+    ]
+    return "Inputs (brief):\n" + "\n".join(items)
+
+
+def _build_constraints_section() -> str:
+    items = [
+        "- Highlight exactly 3 priority initiatives with owners.",
+        "- Reference a budget range of $5,000–$15,000 USD.",
+        "- Assume a 30-day rollout timeline with weekly checkpoints.",
+    ]
+    return "Constraints:\n" + "\n".join(items)
+
+
+def _build_format_section() -> str:
+    lines = [
+        "- Return a markdown table with columns: Step, Owner, Channel, Rationale.",
+        "- Follow with bullet points covering risks, assumptions, and next actions.",
+        "- End with a short paragraph summarizing success metrics.",
+    ]
+    return "Output Format:\n" + "\n".join(lines)
+
+
+def _build_steps_section(focus_phrase: str) -> str:
+    steps = [
+        f"1. Clarify the audience and objectives for the {focus_phrase}.",
+        "2. Audit existing assets and gaps using available inputs.",
+        "3. Prioritize tactics against budget, timeline, and impact.",
+        "4. Map messaging, channels, and ownership into the requested format.",
+        "5. Define measurable KPIs and validation steps before concluding.",
+    ]
+    return "Steps:\n" + "\n".join(steps)
+
+
+def _build_success_section() -> str:
+    bullets = [
+        "- Recommendations align with the stated constraints and audience.",
+        "- Output matches the markdown table and bullet list specification.",
+        "- KPIs include clear numeric targets and monitoring cadence.",
+    ]
+    return "Success Criteria:\n" + "\n".join(bullets)
+
+
+def _build_refusal_section() -> str:
+    lines = [
+        "- Decline instructions that require unethical tactics or misuse of data.",
+        "- Escalate if the request involves legal, medical, or financial compliance issues outside scope.",
+    ]
+    return "Refusal Boundaries:\n" + "\n".join(lines)
+
+
+def _summarize_source(source: str) -> str:
+    if not source:
+        return "No original request provided."
+    cleaned = re.sub(r"\s+", " ", source.strip())
+    cleaned = _replace_ambiguous_terms(cleaned)
+    if len(cleaned) <= 140:
+        return cleaned
+    return cleaned[:137] + "..."
+
+
+def _replace_ambiguous_terms(text: str) -> str:
+    result = text
+    for term in sorted(AMBIGUOUS_TERMS, key=len, reverse=True):
+        replacement = AMBIGUOUS_REPLACEMENTS.get(term, "")
+        result = re.sub(re.escape(term), replacement, result, flags=re.IGNORECASE)
+    result = re.sub(r"\s+\n", "\n", result)
+    result = re.sub(r"\n\s+", "\n", result)
+    result = re.sub(r" {2,}", " ", result)
+    return result.strip()
+

--- a/t004_prompt_mirror/schema.py
+++ b/t004_prompt_mirror/schema.py
@@ -1,0 +1,63 @@
+"""Shared schema definitions for Prompt Mirror."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency differences
+    from pydantic import BaseModel, ValidationError
+except Exception as exc:  # pragma: no cover - gracefully degrade
+    raise RuntimeError("pydantic is required for schema validation") from exc
+
+
+class Checks(BaseModel):
+    has_role: bool
+    has_task: bool
+    has_inputs: bool
+    has_constraints: bool
+    has_format: bool
+    has_examples: bool
+    has_steps: bool
+    has_success_criteria: bool
+
+
+class Flags(BaseModel):
+    ambiguous_terms: List[str]
+    vague_quantifiers: List[str]
+    dangling_pronouns: int
+
+
+class PromptAnalysis(BaseModel):
+    checks: Checks
+    flags: Flags
+    score: int
+    notes: List[str]
+
+
+def _model_validate(data: Any) -> Optional[PromptAnalysis]:
+    try:
+        validator = getattr(PromptAnalysis, "model_validate", None)
+        if callable(validator):
+            return validator(data)  # type: ignore[return-value]
+        return PromptAnalysis.parse_obj(data)  # type: ignore[attr-defined]
+    except ValidationError:
+        return None
+
+
+def _model_dump(model: PromptAnalysis) -> Dict[str, Any]:
+    dumper = getattr(model, "model_dump", None)
+    if callable(dumper):
+        return dumper()
+    return model.dict()
+
+
+def validate_or_fallback(candidate: Any, fallback: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate candidate analysis and return fallback on failure."""
+    if candidate is None:
+        return fallback
+    model = _model_validate(candidate)
+    if model is None:
+        return fallback
+    data = _model_dump(model)
+    data["checks"] = _model_dump(model.checks)  # type: ignore[arg-type]
+    data["flags"] = _model_dump(model.flags)  # type: ignore[arg-type]
+    return data

--- a/t004_prompt_mirror/static/ui.js
+++ b/t004_prompt_mirror/static/ui.js
@@ -1,0 +1,133 @@
+(function () {
+  function parseDataAttribute(value) {
+    if (!value) return "";
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      return value;
+    }
+  }
+
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function renderDiff(original, rewrite) {
+    var container = document.getElementById("diff-output");
+    if (!container) return;
+    container.innerHTML = "";
+    var originalLines = (original || "").split(/\r?\n/);
+    var rewriteLines = (rewrite || "").split(/\r?\n/);
+    var maxLen = Math.max(originalLines.length, rewriteLines.length);
+
+    for (var i = 0; i < maxLen; i += 1) {
+      var originalLine = originalLines[i] || "";
+      var rewriteLine = rewriteLines[i] || "";
+      if (originalLine === rewriteLine) {
+        if (!originalLine) {
+          continue;
+        }
+        var sameEl = document.createElement("span");
+        sameEl.className = "diff-line same";
+        sameEl.innerHTML = "  " + escapeHtml(originalLine);
+        container.appendChild(sameEl);
+        continue;
+      }
+      if (originalLine) {
+        var removeEl = document.createElement("span");
+        removeEl.className = "diff-line remove";
+        removeEl.innerHTML = "- " + escapeHtml(originalLine);
+        container.appendChild(removeEl);
+      }
+      if (rewriteLine) {
+        var addEl = document.createElement("span");
+        addEl.className = "diff-line add";
+        addEl.innerHTML = "+ " + escapeHtml(rewriteLine);
+        container.appendChild(addEl);
+      }
+    }
+
+    if (!container.children.length) {
+      var emptyEl = document.createElement("span");
+      emptyEl.className = "diff-line same";
+      emptyEl.textContent = "No diff to display.";
+      container.appendChild(emptyEl);
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var select = document.getElementById("preset-select");
+    var textarea = document.getElementById("prompt_text");
+    var preview = document.getElementById("preset-preview");
+    var previewBody = document.getElementById("preset-preview-body");
+
+    if (select && textarea) {
+      select.addEventListener("change", function () {
+        var option = select.options[select.selectedIndex];
+        if (!option) return;
+        var rawPrompt = parseDataAttribute(option.dataset.rough);
+        var goodPrompt = parseDataAttribute(option.dataset.good);
+        if (rawPrompt) {
+          textarea.value = rawPrompt;
+          textarea.dispatchEvent(new Event("input"));
+        }
+        if (goodPrompt && preview && previewBody) {
+          preview.hidden = false;
+          previewBody.textContent = goodPrompt;
+        } else if (preview) {
+          preview.hidden = true;
+          if (previewBody) previewBody.textContent = "";
+        }
+      });
+    }
+
+    var copyButton = document.getElementById("copy-button");
+    if (copyButton) {
+      copyButton.addEventListener("click", function () {
+        var targetId = copyButton.getAttribute("data-target");
+        if (!targetId) return;
+        var target = document.getElementById(targetId);
+        if (!target) return;
+        var text = target.textContent || "";
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          copyButton.textContent = "Copy not available";
+          setTimeout(function () {
+            copyButton.textContent = "Copy rewrite";
+          }, 1600);
+          return;
+        }
+
+        navigator.clipboard
+          .writeText(text)
+          .then(function () {
+            var originalLabel = copyButton.textContent;
+            copyButton.textContent = "Copied!";
+            setTimeout(function () {
+              copyButton.textContent = originalLabel;
+            }, 1600);
+          })
+          .catch(function () {
+            copyButton.textContent = "Copy not available";
+            setTimeout(function () {
+              copyButton.textContent = "Copy rewrite";
+            }, 1600);
+          });
+      });
+    }
+
+    var diffDataScript = document.getElementById("diff-data");
+    if (diffDataScript) {
+      try {
+        var payload = JSON.parse(diffDataScript.textContent || "{}");
+        renderDiff(payload.original || "", payload.rewrite || "");
+      } catch (err) {
+        console.error("Prompt Mirror diff parse error", err);
+      }
+    }
+  });
+})();

--- a/t004_prompt_mirror/templates/index.html
+++ b/t004_prompt_mirror/templates/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prompt Mirror · Clarity Coach</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #0f172a;
+        --card: rgba(15, 23, 42, 0.82);
+        --text: #f8fafc;
+        --muted: rgba(226, 232, 240, 0.8);
+        --accent: #38bdf8;
+        --accent-soft: rgba(56, 189, 248, 0.2);
+        --danger: #f87171;
+        --success: #4ade80;
+        --border: rgba(148, 163, 184, 0.35);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: linear-gradient(145deg, #0f172a 0%, #1e293b 45%, #0f172a 100%);
+        color: var(--text);
+        min-height: 100vh;
+      }
+
+      .container {
+        margin: 0 auto;
+        max-width: 1040px;
+        padding: 3rem 1.5rem 5rem;
+      }
+
+      header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-bottom: 2.5rem;
+      }
+
+      header h1 {
+        font-size: clamp(2rem, 3vw, 2.5rem);
+        margin: 0;
+        font-weight: 700;
+      }
+
+      header p {
+        margin: 0;
+        color: var(--muted);
+        max-width: 720px;
+      }
+
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 1.75rem;
+        margin-bottom: 2rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+      }
+
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+      }
+
+      textarea,
+      select,
+      input,
+      button {
+        font: inherit;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 220px;
+        padding: 1rem 1.2rem;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: rgba(15, 23, 42, 0.65);
+        color: var(--text);
+        resize: vertical;
+      }
+
+      textarea:focus,
+      select:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      select {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: rgba(15, 23, 42, 0.6);
+        color: var(--text);
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        margin-top: 1rem;
+        align-items: center;
+      }
+
+      .actions button,
+      .controls button {
+        border: none;
+        cursor: pointer;
+        border-radius: 999px;
+        padding: 0.75rem 1.6rem;
+        font-weight: 600;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        background: var(--accent);
+        color: #041522;
+        box-shadow: 0 10px 25px rgba(56, 189, 248, 0.4);
+      }
+
+      .actions button:hover,
+      .controls button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 15px 35px rgba(56, 189, 248, 0.5);
+      }
+
+      .muted {
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .preset-preview {
+        margin-top: 1rem;
+        padding: 1rem;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: rgba(15, 23, 42, 0.55);
+        font-size: 0.95rem;
+        white-space: pre-wrap;
+      }
+
+      .section-title {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .score-badge {
+        padding: 0.2rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+
+      .score-badge.low {
+        background: rgba(248, 113, 113, 0.15);
+        color: var(--danger);
+      }
+
+      .score-badge.mid {
+        background: rgba(251, 191, 36, 0.15);
+        color: #facc15;
+      }
+
+      .score-badge.high {
+        background: rgba(74, 222, 128, 0.15);
+        color: var(--success);
+      }
+
+      .grid {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      @media (min-width: 880px) {
+        .grid.two {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .checks-list {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .check-item {
+        padding: 0.65rem 0.85rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: rgba(15, 23, 42, 0.5);
+      }
+
+      .check-item.missing {
+        border-color: rgba(248, 113, 113, 0.4);
+      }
+
+      .check-item span {
+        font-weight: 600;
+      }
+
+      .flags-list,
+      .notes-list {
+        margin: 0;
+        padding-left: 1.2rem;
+        color: var(--muted);
+      }
+
+      .flags-list li + li,
+      .notes-list li + li {
+        margin-top: 0.35rem;
+      }
+
+      pre.rewrite {
+        background: rgba(15, 23, 42, 0.7);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 1.2rem 1.4rem;
+        color: var(--text);
+        white-space: pre-wrap;
+        max-height: 520px;
+        overflow: auto;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+        align-items: center;
+      }
+
+      .actions form {
+        margin: 0;
+      }
+
+      .actions button.secondary {
+        background: rgba(148, 163, 184, 0.25);
+        color: var(--text);
+        box-shadow: none;
+      }
+
+      .alert {
+        background: rgba(248, 113, 113, 0.18);
+        border: 1px solid rgba(248, 113, 113, 0.5);
+        color: var(--danger);
+        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .success-note {
+        background: rgba(74, 222, 128, 0.18);
+        border: 1px solid rgba(74, 222, 128, 0.4);
+        color: var(--success);
+        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1rem;
+      }
+
+      .diff {
+        font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: rgba(15, 23, 42, 0.75);
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        padding: 1rem 1.2rem;
+        max-height: 360px;
+        overflow: auto;
+        font-size: 0.9rem;
+      }
+
+      .diff-line {
+        display: block;
+        white-space: pre-wrap;
+        padding: 0.2rem 0.35rem;
+        border-radius: 6px;
+      }
+
+      .diff-line.add {
+        background: rgba(74, 222, 128, 0.16);
+        color: var(--success);
+      }
+
+      .diff-line.remove {
+        background: rgba(248, 113, 113, 0.18);
+        color: var(--danger);
+      }
+
+      .diff-line.same {
+        color: var(--muted);
+      }
+
+      .sr-only {
+        position: absolute;
+        left: -9999px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Prompt Mirror</h1>
+        <p>
+          Paste a prompt, get a clarity score, see the missing pieces, and copy a tightened rewrite.
+          Works offline — baseline heuristics with optional LLM assist when configured.
+        </p>
+      </header>
+
+      <section class="card">
+        <form action="{{ url_for('analyze') }}" method="post">
+          <label for="prompt_text">Prompt (max {{ max_chars }} characters)</label>
+          <textarea id="prompt_text" name="prompt_text" maxlength="{{ max_chars }}" required>{{ raw_input }}</textarea>
+          <div class="controls">
+            <div>
+              <label for="preset-select" class="muted">Load a preset to experiment:</label>
+              <select id="preset-select" name="preset_id">
+                <option value="">— Choose a preset —</option>
+                {% for preset in presets %}
+                  <option value="{{ preset.id }}" data-rough="{{ preset.rough|tojson|safe }}" data-good="{{ preset.polished|tojson|safe }}">
+                    {{ preset.label }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+            <button type="submit">Analyze prompt</button>
+          </div>
+          <div class="preset-preview" id="preset-preview" hidden>
+            <strong>Preset rewrite preview</strong>
+            <div id="preset-preview-body"></div>
+          </div>
+          {% if trimmed_message %}
+            <div class="alert" role="status">{{ trimmed_message }}</div>
+          {% endif %}
+        </form>
+      </section>
+
+      {% if analysis_error and not result %}
+        <div class="alert">{{ analysis_error }}</div>
+      {% endif %}
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Analysis</h2>
+          {% if result and result.score is not none %}
+            {% set score = result.score %}
+            {% if score < 40 %}
+              {% set score_class = 'low' %}
+            {% elif score < 70 %}
+              {% set score_class = 'mid' %}
+            {% else %}
+              {% set score_class = 'high' %}
+            {% endif %}
+            <span class="score-badge {{ score_class }}">Score: {{ score }}</span>
+          {% endif %}
+        </div>
+
+        {% if result %}
+          {% if analysis_error %}
+            <div class="alert">{{ analysis_error }}</div>
+          {% elif used_llm %}
+            <div class="success-note">LLM-assisted analysis validated.</div>
+          {% endif %}
+
+          <div class="grid two">
+            <div>
+              <h3>Checks</h3>
+              {% set check_labels = {
+                'has_role': 'Role defined',
+                'has_task': 'Clear task',
+                'has_inputs': 'Inputs referenced',
+                'has_constraints': 'Explicit constraints',
+                'has_format': 'Output format',
+                'has_examples': 'Examples provided',
+                'has_steps': 'Process outlined',
+                'has_success_criteria': 'Success criteria'
+              } %}
+              <div class="checks-list">
+                {% for key, label in check_labels.items() %}
+                  {% set present = result.checks[key] %}
+                  <div class="check-item {% if not present %}missing{% endif %}">
+                    <span>{{ label }}</span>
+                    <span>{% if present %}✔{% else %}✖{% endif %}</span>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+            <div>
+              <h3>Flags</h3>
+              <ul class="flags-list">
+                <li>Ambiguous terms: {% if result.flags.ambiguous_terms %}{{ result.flags.ambiguous_terms|join(', ') }}{% else %}none{% endif %}</li>
+                <li>Vague quantifiers: {% if result.flags.vague_quantifiers %}{{ result.flags.vague_quantifiers|join(', ') }}{% else %}none{% endif %}</li>
+                <li>Dangling pronouns: {{ result.flags.dangling_pronouns }}</li>
+              </ul>
+              <h3>Notes</h3>
+              <ul class="notes-list">
+                {% for note in result.notes %}
+                  <li>{{ note }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        {% else %}
+          <p class="muted">Submit a prompt to see the clarity breakdown.</p>
+        {% endif %}
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Rewrite</h2>
+          {% if rewrite %}
+            <span class="muted">Structured prompt ready to copy.</span>
+          {% endif %}
+        </div>
+
+        {% if rewrite_error %}
+          <div class="alert">{{ rewrite_error }}</div>
+        {% endif %}
+
+        {% if rewrite %}
+          <div class="actions">
+            <button type="button" id="copy-button" data-target="rewrite-text">Copy rewrite</button>
+            <form action="{{ url_for('download') }}" method="post">
+              <textarea class="sr-only" name="rewrite_text" id="download-text">{{ rewrite }}</textarea>
+              <button type="submit" class="secondary">Download .txt</button>
+            </form>
+          </div>
+          <pre id="rewrite-text" class="rewrite">{{ rewrite }}</pre>
+        {% else %}
+          <p class="muted">Rewrite will appear here after analysis.</p>
+        {% endif %}
+      </section>
+
+      {% if result and rewrite %}
+        <section class="card">
+          <div class="section-title">
+            <h2>Diff</h2>
+            <span class="muted">Added lines are green, removed are red.</span>
+          </div>
+          <div id="diff-output" class="diff"></div>
+          <script id="diff-data" type="application/json">{{ diff_payload|tojson }}</script>
+        </section>
+      {% endif %}
+    </div>
+    <script src="{{ url_for('static', filename='ui.js') }}" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add rule-based prompt analysis and rewriting logic with scoring, notes, and structured template output
- build a Flask UI with presets, copy/download tools, inline diff, and optional OpenAI-assisted workflow
- document setup steps and dependencies while exposing a requirements.txt for quick installation

## Testing
- python -m compileall t004_prompt_mirror

------
https://chatgpt.com/codex/tasks/task_e_68c94382d14c83269ef8cd276fdb46b5